### PR TITLE
Send grasp result once per episode

### DIFF
--- a/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
+++ b/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
@@ -70,6 +70,8 @@ public class AluminumCanA2CClient : MonoBehaviour
     private bool isEpisodeActive = false;
     private bool hasEvaluatedThisEpisode = false;
     private int currentEpisodeNumber = 0;
+    // 一回のエピソードで結果を送信したかのフラグ
+    private bool episodeResultSent = false;
     
     // 🔥 把持力指令関連
     private Queue<float> gripForceCommandQueue = new Queue<float>();
@@ -256,31 +258,30 @@ public class AluminumCanA2CClient : MonoBehaviour
         gripForceCommandsReceived++;
         
         Debug.Log($"🔥 把持力指令受信完了: {gripForce:F2}N (受信数: {gripForceCommandsReceived})");
-        
-        // イベント発火
-        OnGripForceCommandReceived?.Invoke(gripForce);
-        Debug.Log($"🔥 イベント発火完了");
-        
-        // 🔥 AutoEpisodeManagerに転送
-        if (enableGripForceForwarding && episodeManager != null)
+
+        if (enableGripForceForwarding)
         {
-            episodeManager.OnTcpGripForceCommandReceived(gripForce);
-            gripForceCommandsForwarded++;
-            
-            Debug.Log($"🔥 把持力指令転送完了: {gripForce:F2}N -> AutoEpisodeManager (転送数: {gripForceCommandsForwarded})");
-        }
-        else
-        {
-            if (!enableGripForceForwarding)
+            if (OnGripForceCommandReceived != null)
             {
-                Debug.LogWarning($"⚠️ 把持力転送が無効化されています");
+                OnGripForceCommandReceived.Invoke(gripForce);
+                Debug.Log($"🔥 イベント発火完了");
             }
-            if (episodeManager == null)
+            else if (episodeManager != null)
+            {
+                episodeManager.OnTcpGripForceCommandReceived(gripForce);
+                gripForceCommandsForwarded++;
+                Debug.Log($"🔥 把持力指令転送完了: {gripForce:F2}N -> AutoEpisodeManager (転送数: {gripForceCommandsForwarded})");
+            }
+            else
             {
                 Debug.LogWarning($"⚠️ EpisodeManagerが設定されていません");
             }
         }
-        
+        else
+        {
+            Debug.LogWarning($"⚠️ 把持力転送が無効化されています");
+        }
+
         Debug.Log($"🔥 把持力指令処理完了: {gripForce:F2}N");
     }
     
@@ -666,12 +667,27 @@ public class AluminumCanA2CClient : MonoBehaviour
     {
         SendMessage("RESET");
         hasEvaluatedThisEpisode = false;
+        // 次のエピソードのために結果送信フラグをリセット
+        episodeResultSent = false;
     }
-    
+
     public void SendEpisodeEnd()
     {
         SendMessage("EPISODE_END");
         hasEvaluatedThisEpisode = true;
+    }
+
+    /// <summary>
+    /// エピソードの成功/失敗結果を送信
+    /// </summary>
+    /// <param name="wasSuccessful">成功した場合は true</param>
+    public void SendEpisodeResult(bool wasSuccessful)
+    {
+        if (episodeResultSent) return;
+
+        string resultMessage = wasSuccessful ? "RESULT_SUCCESS" : "RESULT_FAIL";
+        SendMessage(resultMessage);
+        episodeResultSent = true;
     }
     
     #endregion

--- a/PickAndPlaceProject/Assets/Scripts/AutoEpisodeManager.cs
+++ b/PickAndPlaceProject/Assets/Scripts/AutoEpisodeManager.cs
@@ -589,6 +589,8 @@ public class AutoEpisodeManager : MonoBehaviour
         
         if (a2cClient != null)
         {
+            // エピソード結果を送信（1回のみ）
+            a2cClient.SendEpisodeResult(wasSuccessful);
             a2cClient.SendEpisodeEnd();
         }
         


### PR DESCRIPTION
## Summary
- Send TCP grasp result only once per episode
- Reset sent-result flag with episode reset
- Avoid duplicate grip-force forwarding by deferring to event subscribers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8249e0c988329843b8fc33b2d204d