### PR TITLE
Prevent duplicate episode result messages

### DIFF
--- a/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
+++ b/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
@@ -688,6 +688,7 @@ public class AluminumCanA2CClient : MonoBehaviour
 
         string resultMessage = wasSuccessful ? "RESULT_SUCCESS" : "RESULT_FAIL";
         SendMessage(resultMessage);
+        episodeResultSent = true;
         Debug.Log($"📤 エピソード結果送信: {resultMessage}");
     }
     


### PR DESCRIPTION
## Summary
- Set `episodeResultSent` flag after sending an episode result to avoid duplicate transmissions within the same episode.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b82f6bb33c8329a7ba92774e8fd474