### PR TITLE
Clear episode coroutine reference after session completion

### DIFF
--- a/PickAndPlaceProject/Assets/Scripts/AutoEpisodeManager.cs
+++ b/PickAndPlaceProject/Assets/Scripts/AutoEpisodeManager.cs
@@ -490,8 +490,9 @@ public class AutoEpisodeManager : MonoBehaviour
             Debug.Log("🏁 すべてのエピソードが完了しました");
             ShowFinalStatistics();
         }
-        
+
         OnSessionCompleted?.Invoke();
+        episodeLoopCoroutine = null;
     }
     
     // 🔥 TCP指令待機のコルーチン


### PR DESCRIPTION
## Summary
- Reset `episodeLoopCoroutine` when `ExecuteEpisodeLoop` finishes to allow restarting sessions.

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b833e039ac8329b6ee4168ee8fed8b