### PR TITLE
Add connection flag to prevent duplicate wiring

### DIFF
--- a/PickAndPlaceProject/Assets/Scripts/TcpGripForceConnector.cs
+++ b/PickAndPlaceProject/Assets/Scripts/TcpGripForceConnector.cs
@@ -16,6 +16,7 @@ public class TcpGripForceConnector : MonoBehaviour
     [Header("⚙️ 設定")]
     public bool enableAutoConnection = true;
     public bool enableDebugLogs = true;
+    private bool isConnected = false;
     
     void Start()
     {
@@ -30,6 +31,11 @@ public class TcpGripForceConnector : MonoBehaviour
     /// </summary>
     void SetupConnections()
     {
+        if (isConnected)
+        {
+            return;
+        }
+
         // コンポーネントの自動検索
         if (episodeManager == null)
             episodeManager = FindObjectOfType<AutoEpisodeManager>();
@@ -48,6 +54,8 @@ public class TcpGripForceConnector : MonoBehaviour
             a2cClient.OnGripForceCommandReceived = new System.Action<float>(OnGripForceReceived);
         else
             a2cClient.OnGripForceCommandReceived += OnGripForceReceived;
+
+        isConnected = true;
         
         // 相互参照の設定
         if (a2cClient.episodeManager == null)
@@ -171,10 +179,15 @@ public class TcpGripForceConnector : MonoBehaviour
     
     void OnDestroy()
     {
+        if (!isConnected)
+            return;
+
         // イベントの解除
         if (a2cClient != null && a2cClient.OnGripForceCommandReceived != null)
         {
             a2cClient.OnGripForceCommandReceived -= OnGripForceReceived;
         }
+
+        isConnected = false;
     }
 }


### PR DESCRIPTION
## Summary
- Prevent multiple event subscriptions in `TcpGripForceConnector` using an `isConnected` flag
- Safely unsubscribe and reset the flag on destroy

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b833e2acfc832983c4a4382786be2f