### PR TITLE
Refresh contact state before sending TCP data

### DIFF
--- a/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
+++ b/PickAndPlaceProject/Assets/Scripts/AluminumCanA2CClient.cs
@@ -544,6 +544,13 @@ public class AluminumCanA2CClient : MonoBehaviour
         try
         {
             var state = CollectCanStateData();
+
+            // 🔁 送信直前に接触状態を最新のものに更新
+            if (gripperInterface != null)
+            {
+                state.hasContact = gripperInterface.HasValidContact();
+            }
+
             string jsonData = CreateStateJson(state);
             
             SendMessage(jsonData);


### PR DESCRIPTION
## Summary
- Refresh gripper contact state immediately before serializing can state

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98447cf4c8329892eb1b2c2386587